### PR TITLE
Refactors CLI option parsing for improved error handling

### DIFF
--- a/lib/pix/command/cache.ex
+++ b/lib/pix/command/cache.ex
@@ -5,7 +5,7 @@ defmodule Pix.Command.Cache do
 
   @spec cmd(Pix.Config.t(), OptionParser.argv()) :: :ok
   def cmd(config, argv) do
-    {_cli_opts, args} = OptionParser.parse!(argv, strict: @cli_args)
+    {_cli_opts, args} = Pix.Helper.option_parser_parse!(argv, strict: @cli_args)
 
     case args do
       ["info"] ->

--- a/lib/pix/command/graph.ex
+++ b/lib/pix/command/graph.ex
@@ -5,7 +5,7 @@ defmodule Pix.Command.Graph do
 
   @spec cmd(Pix.UserSettings.t(), Pix.Config.t(), OptionParser.argv()) :: :ok
   def cmd(user_settings, config, argv) do
-    {cli_opts, args} = OptionParser.parse!(argv, strict: @cli_args)
+    {cli_opts, args} = Pix.Helper.option_parser_parse!(argv, strict: @cli_args)
     cli_opts = Keyword.merge(cli_opts, user_settings.command.graph.cli_opts)
     config_pipelines = config.pipelines
 

--- a/lib/pix/command/ls.ex
+++ b/lib/pix/command/ls.ex
@@ -5,7 +5,7 @@ defmodule Pix.Command.Ls do
 
   @spec cmd(Pix.UserSettings.t(), Pix.Config.t(), OptionParser.argv()) :: :ok
   def cmd(user_settings, config, argv) do
-    {cli_opts, args} = OptionParser.parse!(argv, strict: @cli_args)
+    {cli_opts, args} = Pix.Helper.option_parser_parse!(argv, strict: @cli_args)
     cli_opts = Keyword.merge(cli_opts, user_settings.command.ls.cli_opts)
     verbose? = Keyword.get(cli_opts, :verbose, false)
     hidden? = Keyword.get(cli_opts, :hidden, false)

--- a/lib/pix/command/run.ex
+++ b/lib/pix/command/run.ex
@@ -15,7 +15,7 @@ defmodule Pix.Command.Run do
 
   @spec cmd(Pix.UserSettings.t(), Pix.Config.t(), OptionParser.argv()) :: :ok
   def cmd(user_settings, config, argv) do
-    {cli_opts, args} = OptionParser.parse!(argv, strict: @cli_args)
+    {cli_opts, args} = Pix.Helper.option_parser_parse!(argv, strict: @cli_args)
     cli_opts = Keyword.merge(cli_opts, user_settings.command.run.cli_opts)
     config_pipelines = config.pipelines
 

--- a/lib/pix/command/shell.ex
+++ b/lib/pix/command/shell.ex
@@ -11,7 +11,7 @@ defmodule Pix.Command.Shell do
 
   @spec cmd(Pix.UserSettings.t(), Pix.Config.t(), OptionParser.argv()) :: :ok
   def cmd(user_settings, config, argv) do
-    {cli_opts, args} = OptionParser.parse!(argv, strict: @cli_args)
+    {cli_opts, args} = Pix.Helper.option_parser_parse!(argv, strict: @cli_args)
     cli_opts = Keyword.merge(cli_opts, user_settings.command.shell.cli_opts)
     config_pipelines = config.pipelines
 

--- a/lib/pix/command/upgrade.ex
+++ b/lib/pix/command/upgrade.ex
@@ -7,7 +7,8 @@ defmodule Pix.Command.Upgrade do
 
   @spec cmd(Pix.UserSettings.t(), OptionParser.argv()) :: :ok
   def cmd(user_settings, argv) do
-    {cli_opts, _args} = OptionParser.parse!(argv, strict: @cli_args)
+    {cli_opts, _args} = Pix.Helper.option_parser_parse!(argv, strict: @cli_args)
+
     cli_opts = Keyword.merge(cli_opts, user_settings.command.upgrade.cli_opts)
     dry_run? = Keyword.get(cli_opts, :dry_run, false)
 

--- a/lib/pix/helper.ex
+++ b/lib/pix/helper.ex
@@ -41,4 +41,18 @@ defmodule Pix.Helper do
       Exception.message(e) |> IO.puts()
       System.halt(1)
   end
+
+  @spec option_parser_parse!(OptionParser.argv(), OptionParser.options()) ::
+          {OptionParser.parsed(), args :: [String.t()]}
+  def option_parser_parse!(argv, opts) do
+    case OptionParser.parse(argv, opts) do
+      {cli_opts, args, []} ->
+        {cli_opts, args}
+
+      {_, _, invalid} ->
+        msgs = Enum.map_join(invalid, "\n", fn {opt, _} -> "  invalid option: #{opt}" end)
+        Pix.Report.error("#{msgs}\n")
+        System.halt(1)
+    end
+  end
 end


### PR DESCRIPTION
Replaces direct usage of the built-in option parser with a helper function that provides consistent invalid option handling and user feedback. Ensures early failure and clear error reporting when unrecognized options are provided, improving CLI robustness.