### PR TITLE
Add --save option to `pix run` for exporting docker images

### DIFF
--- a/lib/pix/command/help.ex
+++ b/lib/pix/command/help.ex
@@ -75,7 +75,7 @@ defmodule Pix.Command.Help do
 
   defp help_cmd("run") do
     """
-    #{_cmd("pix run")} [#{_opt("--output")}] [#{_opt("--ssh SPEC")} ...] [#{_opt("--arg ARG")} ...] [#{_opt("--progress PROGRESS")}] [#{_opt("--target TARGET")} [#{_opt("--tag TAG")}]] [#{_opt("--no-cache")}] [#{_opt("--no-cache-filter TARGET")} ...] PIPELINE
+    #{_cmd("pix run")} [#{_opt("--output")}] [#{_opt("--ssh SPEC")} ...] [#{_opt("--arg ARG")} ...] [#{_opt("--progress PROGRESS")}] [#{_opt("--target TARGET")} [#{_opt("--tag TAG")} [#{_opt("--save PATH")}]]] [#{_opt("--no-cache")}] [#{_opt("--no-cache-filter TARGET")} ...] PIPELINE
 
       Run PIPELINE.
 
@@ -90,6 +90,9 @@ defmodule Pix.Command.Help do
           #{_opt("--arg")}*              Set one or more pipeline ARG (format KEY=value)
           #{_opt("--no-cache-filter")}*  Do not cache specified targets
           #{_opt("--progress")}          Set type of progress output - "auto", "plain", "tty", "rawjson" (default "auto")
+          #{_opt("--save")}              Save the TARGET's docker image to PATH using `buildx --output type=docker`.
+                              Automatically compresses with gzip if PATH ends with .gz.
+                              Requires --target and --tag.
           #{_opt("--secret")}*           Forward one or more secrets to `buildx build`
           #{_opt("--ssh")}*              Forward SSH agent/keys to `buildx build` (format: default|<id>[=<socket>|<key>[,<key>]]).
                               Can be specified multiple times.

--- a/lib/pix/command/run.ex
+++ b/lib/pix/command/run.ex
@@ -7,6 +7,7 @@ defmodule Pix.Command.Run do
     no_cache_filter: [:string, :keep],
     output: :boolean,
     progress: :string,
+    save: :string,
     secret: [:string, :keep],
     ssh: [:string, :keep],
     tag: :string,
@@ -42,6 +43,12 @@ defmodule Pix.Command.Run do
   defp validate_run_cli_opts!(cli_opts) do
     if Keyword.has_key?(cli_opts, :tag) and not Keyword.has_key?(cli_opts, :target) do
       Pix.Report.error("--tag option requires a --target\n")
+      System.halt(1)
+    end
+
+    if Keyword.has_key?(cli_opts, :save) and
+         (not Keyword.has_key?(cli_opts, :target) or not Keyword.has_key?(cli_opts, :tag)) do
+      Pix.Report.error("--save option requires both --target and --tag\n")
       System.halt(1)
     end
 

--- a/lib/pix/pipeline.ex
+++ b/lib/pix/pipeline.ex
@@ -7,6 +7,7 @@ defmodule Pix.Pipeline do
           | {:no_cache, boolean()}
           | {:output, boolean()}
           | {:progress, String.t()}
+          | {:save, String.t()}
           | {:secret, String.t()}
           | {:ssh, String.t()}
           | {:tag, String.t()}
@@ -49,8 +50,15 @@ defmodule Pix.Pipeline do
     build_opts = run_build_options(cli_opts, pipeline, pipeline_target, from, ctx_dir, default_args)
     execute_run_build(build_opts, dockerfile_path, cli_opts, targets)
 
-    if Keyword.has_key?(cli_opts, :target) and Keyword.has_key?(cli_opts, :tag) do
-      execute_tag(build_opts, dockerfile_path, cli_opts)
+    cond do
+      Keyword.has_key?(cli_opts, :save) ->
+        execute_save(build_opts, dockerfile_path, cli_opts)
+
+      Keyword.has_key?(cli_opts, :target) and Keyword.has_key?(cli_opts, :tag) ->
+        execute_tag(build_opts, dockerfile_path, cli_opts)
+
+      true ->
+        :ok
     end
 
     :ok
@@ -222,6 +230,46 @@ defmodule Pix.Pipeline do
     ssh_opts = Keyword.get_values(cli_opts, :ssh)
 
     Pix.Docker.build(ssh_opts, build_opts, ".") |> halt_on_error()
+
+    :ok
+  end
+
+  @spec execute_save(Pix.Docker.opts(), Path.t(), run_cli_opts()) :: :ok
+  defp execute_save(build_opts, dockerfile_path, cli_opts) do
+    save_path = Path.expand(cli_opts[:save])
+
+    {dest_path, compress?} =
+      if String.ends_with?(save_path, ".gz") do
+        {Path.rootname(save_path), true}
+      else
+        {save_path, false}
+      end
+
+    Pix.Report.info(
+      "\nSaving pipeline target #{inspect(cli_opts[:target])} as #{inspect(cli_opts[:tag])} to #{save_path}\n\n"
+    )
+
+    build_opts = Enum.reject(build_opts, &(match?(:no_cache, &1) or match?({:no_cache_filter, _}, &1)))
+
+    build_opts =
+      build_opts ++
+        [
+          target: cli_opts[:target],
+          file: dockerfile_path,
+          tag: cli_opts[:tag],
+          output: "type=docker,dest=#{dest_path}"
+        ]
+
+    ssh_opts = Keyword.get_values(cli_opts, :ssh)
+
+    Pix.Docker.build(ssh_opts, build_opts, ".") |> halt_on_error()
+
+    if compress? do
+      Pix.Report.info("\nCompressing #{dest_path} ...\n")
+      {_, 0} = System.cmd("gzip", ["-f", dest_path])
+    end
+
+    Pix.Report.info("\nSaved image to #{save_path}\n")
 
     :ok
   end

--- a/lib/pix/pipeline.ex
+++ b/lib/pix/pipeline.ex
@@ -266,7 +266,13 @@ defmodule Pix.Pipeline do
 
     if compress? do
       Pix.Report.info("\nCompressing #{dest_path} ...\n")
-      {_, 0} = System.cmd("gzip", ["-f", dest_path])
+
+      _compressed =
+        dest_path
+        |> File.stream!(65_536)
+        |> Enum.into(File.stream!(save_path, [:compressed]))
+
+      File.rm!(dest_path)
     end
 
     Pix.Report.info("\nSaved image to #{save_path}\n")

--- a/shell_completions/pix.fish
+++ b/shell_completions/pix.fish
@@ -76,6 +76,7 @@ complete -c pix -n "__fish_seen_subcommand_from run" -l "progress" -d "Set type 
 complete -c pix -n "__fish_seen_subcommand_from run" -l "secret" -d "Forward one or more secrets to `buildx build`"
 complete -c pix -n "__fish_seen_subcommand_from run" -l "target" -d "Run PIPELINE for a specific TARGET" -a "(__pix_get_run_targets)"
 complete -c pix -n "__fish_seen_subcommand_from run" -l "tag" -d "Tag the TARGET's docker image (requires --target)"
+complete -c pix -n "__fish_seen_subcommand_from run" -l "save" -d "Save the TARGET's docker image to a file (requires --target and --tag)" -rF
 complete -c pix -n "__fish_seen_subcommand_from run" -l "no-cache" -d "Do not use cache when building the image"
 complete -c pix -n "__fish_seen_subcommand_from run" -l "no-cache-filter" -d "Do not cache specified targets" -a "(__pix_get_run_targets)"
 


### PR DESCRIPTION
## Add `--save` option to `pix run`

### Summary

Adds a new `--save` option to `pix run` that exports the target's docker image directly to a file, leveraging buildx `--output type=docker,dest=<path>`. If the destination path ends with `.gz`, the tarball is automatically compressed with gzip.

### Motivation

Previously, saving a docker image to a file required a two-step manual process:

```bash
pix run --target=myprj.app --tag="myprj:latest" myprj
docker save myprj:latest | gzip > ~/myprj.tar.gz
```

Now it's a single command:

```bash
pix run  --target=myprj.app --tag="myprj:latest" --save=~/myprj.tar.gz myprj
```

