### PR TITLE
fix: let CLI options take precedence over user settings

### DIFF
--- a/lib/pix/command/graph.ex
+++ b/lib/pix/command/graph.ex
@@ -6,7 +6,7 @@ defmodule Pix.Command.Graph do
   @spec cmd(Pix.UserSettings.t(), Pix.Config.t(), OptionParser.argv()) :: :ok
   def cmd(user_settings, config, argv) do
     {cli_opts, args} = Pix.Helper.option_parser_parse!(argv, strict: @cli_args)
-    cli_opts = Keyword.merge(cli_opts, user_settings.command.graph.cli_opts)
+    cli_opts = Keyword.merge(user_settings.command.graph.cli_opts, cli_opts)
     config_pipelines = config.pipelines
 
     case args do

--- a/lib/pix/command/ls.ex
+++ b/lib/pix/command/ls.ex
@@ -6,7 +6,7 @@ defmodule Pix.Command.Ls do
   @spec cmd(Pix.UserSettings.t(), Pix.Config.t(), OptionParser.argv()) :: :ok
   def cmd(user_settings, config, argv) do
     {cli_opts, args} = Pix.Helper.option_parser_parse!(argv, strict: @cli_args)
-    cli_opts = Keyword.merge(cli_opts, user_settings.command.ls.cli_opts)
+    cli_opts = Keyword.merge(user_settings.command.ls.cli_opts, cli_opts)
     verbose? = Keyword.get(cli_opts, :verbose, false)
     hidden? = Keyword.get(cli_opts, :hidden, false)
     config_pipelines = config.pipelines

--- a/lib/pix/command/run.ex
+++ b/lib/pix/command/run.ex
@@ -17,7 +17,7 @@ defmodule Pix.Command.Run do
   @spec cmd(Pix.UserSettings.t(), Pix.Config.t(), OptionParser.argv()) :: :ok
   def cmd(user_settings, config, argv) do
     {cli_opts, args} = Pix.Helper.option_parser_parse!(argv, strict: @cli_args)
-    cli_opts = Keyword.merge(cli_opts, user_settings.command.run.cli_opts)
+    cli_opts = Keyword.merge(user_settings.command.run.cli_opts, cli_opts)
     config_pipelines = config.pipelines
 
     validate_run_cli_opts!(cli_opts)

--- a/lib/pix/command/shell.ex
+++ b/lib/pix/command/shell.ex
@@ -12,7 +12,7 @@ defmodule Pix.Command.Shell do
   @spec cmd(Pix.UserSettings.t(), Pix.Config.t(), OptionParser.argv()) :: :ok
   def cmd(user_settings, config, argv) do
     {cli_opts, args} = Pix.Helper.option_parser_parse!(argv, strict: @cli_args)
-    cli_opts = Keyword.merge(cli_opts, user_settings.command.shell.cli_opts)
+    cli_opts = Keyword.merge(user_settings.command.shell.cli_opts, cli_opts)
     config_pipelines = config.pipelines
 
     case args do

--- a/lib/pix/command/upgrade.ex
+++ b/lib/pix/command/upgrade.ex
@@ -9,7 +9,7 @@ defmodule Pix.Command.Upgrade do
   def cmd(user_settings, argv) do
     {cli_opts, _args} = Pix.Helper.option_parser_parse!(argv, strict: @cli_args)
 
-    cli_opts = Keyword.merge(cli_opts, user_settings.command.upgrade.cli_opts)
+    cli_opts = Keyword.merge(user_settings.command.upgrade.cli_opts, cli_opts)
     dry_run? = Keyword.get(cli_opts, :dry_run, false)
 
     current_version = Application.fetch_env!(:pix, :version)


### PR DESCRIPTION
## Problem

Options set in `~/.config/pix/settings.exs` silently override values passed explicitly on the command line.

Each command handler merges the user settings on top of the parsed CLI options:

```elixir
cli_opts = Keyword.merge(cli_opts, user_settings.command.shell.cli_opts)
```

`Keyword.merge(a, b)` gives precedence to the **second** argument, so the settings file wins over the CLI.

### Reproduction

With a settings default:

```elixir
%{command: %{shell: %{cli_opts: [ssh: "default=~/.ssh/id_ed25519_work"]}}}
```

running:

```sh
pix shell --ssh="default=~/.ssh/vm_key" dev_tools remote_load.sh my_service:latest 192.168.64.9
```

still mounts `id_ed25519_work` and discards the explicit `--ssh` value:

```
>>> mounting SSH key "/home/meox/.ssh/id_ed25519_work" as /root/.ssh/id_ed25519_work into shell container
root@192.168.64.9: Permission denied (publickey).
```

## Fix

Swap the `Keyword.merge` argument order so user settings act as **defaults** and explicit CLI options take precedence:

```elixir
cli_opts = Keyword.merge(user_settings.command.shell.cli_opts, cli_opts)
```

Applied consistently across all command handlers that perform this merge: `shell`, `run`, `ls`, `graph`, `upgrade`.

## Notes

- Options not provided on the CLI still fall back to the settings value, so existing `settings.exs` defaults keep working.
- For multi-value (`:keep`) options such as `ssh`/`secret`/`arg`, an explicit CLI value now replaces the settings default for that key (CLI wins) rather than being clobbered by it.

## Verification

- `mix compile --warnings-as-errors` passes (pix app)
- `mix format --check-formatted` passes